### PR TITLE
chat-parser: handle whitespace around JSON in tool call parsing

### DIFF
--- a/tests/test-chat.cpp
+++ b/tests/test-chat.cpp
@@ -1018,6 +1018,15 @@ static void test_template_output_parsers() {
                 "<function=special_function>{\"arg1\": 1}</function>",
                 /* is_partial= */ false,
                 {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
+        // Test <function=name> with whitespace before JSON (issue: model outputs newline+spaces before JSON)
+        assert_msg_equals(
+            message_assist_call,
+            common_chat_parse(
+                "<function=special_function>\n"
+                "     {\"arg1\": 1}\n"
+                "</function>",
+                /* is_partial= */ false,
+                {COMMON_CHAT_FORMAT_HERMES_2_PRO}));
         assert_msg_equals(
             message_assist_call,
             common_chat_parse(


### PR DESCRIPTION
## Summary

- Fix parsing failures when models output whitespace between XML tags and JSON content in tool calls
- Modify `try_consume_json()` to skip leading whitespace before parsing and consume trailing whitespace after
- Restore position if JSON parsing fails to preserve streaming/partial parsing behavior

## Problem

Models often output whitespace (newlines, spaces) between XML tags and JSON content:

```xml
<function=transfer_to_human>
     {"reason": "Caller asked for explanation..."}
</function>
```

This was causing parsing failures in Hermes 2 Pro and other formats because `try_consume_json()` expected JSON to start immediately at the current position.

## Solution

Modified `try_consume_json()` to handle whitespace around JSON:
1. Save position before consuming leading whitespace
2. Skip leading whitespace before attempting to parse JSON
3. Consume trailing whitespace after successful JSON parse
4. Restore position if JSON parsing fails (important for streaming)

This fix benefits all chat formats that use `try_consume_json()`, including:
- Hermes 2 Pro (`<function=name>`, `<tool_call>`, etc.)
- Granite (`<|tool_call|>`)
- Nemotron (`<TOOLCALL>`)
- Apertus (`<|tools_prefix|>`)
- LFM2 (`<|tool_call_start|>`)
- And others

## Test plan

- [x] Added test case for `<function=name>` with whitespace before JSON
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)